### PR TITLE
Reduce Identity Deposit

### DIFF
--- a/gosb/bin/node/runtime/src/lib.rs
+++ b/gosb/bin/node/runtime/src/lib.rs
@@ -1394,9 +1394,9 @@ impl pallet_grandpa::Config for Runtime {
 }
 
 parameter_types! {
-	pub const BasicDeposit: Balance = 10 * DOLLARS;       // 258 bytes on-chain
+	pub const BasicDeposit: Balance = 1 * DOLLARS;        // 258 bytes on-chain
 	pub const FieldDeposit: Balance = 250 * CENTS;        // 66 bytes on-chain
-	pub const SubAccountDeposit: Balance = 2 * DOLLARS;   // 53 bytes on-chain
+	pub const SubAccountDeposit: Balance = 1 * DOLLARS;   // 53 bytes on-chain
 	pub const MaxSubAccounts: u32 = 100;
 	pub const MaxAdditionalFields: u32 = 100;
 	pub const MaxRegistrars: u32 = 20;


### PR DESCRIPTION
# Description

Reduction of identity deposit lowered to 100 GOS:

- Reduces the identity pallet deposit to 100 GOS.
- Needed as the identity deposit is too high for the general public.
- No negative impacts are expected from the minimal value change.
